### PR TITLE
tcp: Allow serial number to mismatch in reply

### DIFF
--- a/omnikinverter/tcp.py
+++ b/omnikinverter/tcp.py
@@ -195,10 +195,14 @@ def parse_messages(serial_number: int, data: bytes) -> dict[str, Any]:
     for (message_type, reply_serial_number, message) in _unpack_messages(
         bytearray(data)
     ):
-        if reply_serial_number != serial_number:
-            raise OmnikInverterPacketInvalidError(
-                f"Replied serial number {reply_serial_number} "
-                f"not equal to request {serial_number}"
+        if reply_serial_number != serial_number:  # pragma: no cover
+            # This is allowed as it does not seem to be required to pass the serial
+            # number in the request - though empirical testing has to point out whether
+            # the request takes longer this way.
+            LOGGER.debug(
+                "Replied serial number %s not equal to request %s",
+                reply_serial_number,
+                serial_number,
             )
 
         if message_type == MESSAGE_TYPE_INFORMATION_REPLY:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -429,18 +429,6 @@ async def test_inverter_tcp_end_marker() -> None:
     assert str(excinfo.value) == "Invalid end byte"
 
 
-async def test_inverter_tcp_reply_identical_serial() -> None:
-    """Require replied serial to be identical to the request."""
-
-    with pytest.raises(OmnikInverterPacketInvalidError) as excinfo:
-        assert tcp.parse_messages(1234, load_fixture_bytes("tcp_reply.data"))
-
-    assert (
-        str(excinfo.value)
-        == "Replied serial number 987654321 not equal to request 1234"
-    )
-
-
 async def test_inverter_tcp_known_message_type() -> None:
     """Require message type to be known."""
 


### PR DESCRIPTION
As it turns out the serial number _does not seem_ to be required in the request packet, in order to extract data from the inverter.  This field is present in the "header" around the TCP packet, most likely to keep the format the same between requests and replies but is not actually checked by the inverter before it sends back a valid reply.

By being more lenient here we can recommend - or at least request - the community to test with a nonmatching (e.g. `0`) serial number, instead of having to look it up on the screen or through the `javascript` backend.
