### PR TITLE
tcp: Allow `unknown0` to be `0` in addition to `UINT16_MAX`

### DIFF
--- a/omnikinverter/tcp.py
+++ b/omnikinverter/tcp.py
@@ -226,7 +226,7 @@ def parse_messages(serial_number: int, data: bytes) -> dict[str, Any]:
 def _parse_information_reply(data: bytes) -> dict[str, Any]:
     tcp_data = _TcpData.from_buffer_copy(data)
 
-    if tcp_data.unknown0 != UINT16_MAX:  # pragma: no cover
+    if tcp_data.unknown0 not in [0, UINT16_MAX]:  # pragma: no cover
         LOGGER.warning("Unexpected unknown0 `%s`", tcp_data.unknown0)
 
     if tcp_data.padding0 != b"\x81\x02\x01":  # pragma: no cover


### PR DESCRIPTION
As it turns out this field has a different value on a 4000TL(2?): while it doesn't bring us any closer to the meaning of this field, allow it to not spam the logs full with it.
