### PR TITLE
Add support for SOFAR 2200TL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A python package with which you can read the data from your Omnik Inverter. Keep
 | Bosswerk | BW-MI300         | HTML       |
 | Bosswerk | BW-MI600         | HTML       |
 | Sofar    | 3600TLM          | HTML       |
+| Sofar    | 2200TL           | JS         |
 | Huayu    | HY-600-Pro       | HTML       |
 
 ## Installation

--- a/omnikinverter/models.py
+++ b/omnikinverter/models.py
@@ -155,7 +155,6 @@ class Inverter:
                 if matches[position] != "":
                     if position in [4, 5, 6, 7]:
                         if position in [4, 5]:
-                            # Need to remove spaces before parsing int for SOFAR 2200TL
                             return int(matches[position].replace(" ", ""))
 
                         if position == 6:

--- a/omnikinverter/models.py
+++ b/omnikinverter/models.py
@@ -155,7 +155,8 @@ class Inverter:
                 if matches[position] != "":
                     if position in [4, 5, 6, 7]:
                         if position in [4, 5]:
-                            return int(matches[position])
+                            # Need to remove spaces before parsing int for SOFAR 2200TL
+                            return int(matches[position].replace(" ", ""))
 
                         if position == 6:
                             energy_value = float(matches[position]) / 100

--- a/tests/fixtures/status_devicearray.js
+++ b/tests/fixtures/status_devicearray.js
@@ -1,1 +1,1 @@
-var version= "H4.01.51MW.2.01W1.0.64(2018-01-251-D)";var m2mRssi= "39%";var wanIp= "";var myDeviceArray=new Array();myDeviceArray[0]="12345678910,V4.08Build215,V4.12Build246,Omnik1500tl ,1 000,850,232,52002,,1,";
+var version= "H4.01.51MW.2.01W1.0.64(2018-01-251-D)";var m2mRssi= "39%";var wanIp= "";var myDeviceArray=new Array();myDeviceArray[0]="12345678910,V4.08Build215,V4.12Build246,Omnik1500tl ,,850,232,52002,,1,";

--- a/tests/fixtures/status_devicearray.js
+++ b/tests/fixtures/status_devicearray.js
@@ -1,1 +1,1 @@
-var version= "H4.01.51MW.2.01W1.0.64(2018-01-251-D)";var m2mRssi= "39%";var wanIp= "";var myDeviceArray=new Array();myDeviceArray[0]="12345678910,V4.08Build215,V4.12Build246,Omnik1500tl ,,850,232,52002,,1,";
+var version= "H4.01.51MW.2.01W1.0.64(2018-01-251-D)";var m2mRssi= "39%";var wanIp= "";var myDeviceArray=new Array();myDeviceArray[0]="12345678910,V4.08Build215,V4.12Build246,Omnik1500tl ,1 000,850,232,52002,,1,";

--- a/tests/fixtures/status_devicearray_sofar220tl.js
+++ b/tests/fixtures/status_devicearray_sofar220tl.js
@@ -1,0 +1,1 @@
+var version= "H4.01.51MW.2.01W1.0.64(2018-01-251-D)";var m2mRssi= "39%";var wanIp= "";var myDeviceArray=new Array();myDeviceArray[0]="1234567890  ,V450,,SOFAR2200TL,2 000,400,567,123070,,1,";

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -219,6 +219,36 @@ async def test_inverter_js_devicearray(aresponses: ResponsesMockServer) -> None:
 
 
 @pytest.mark.asyncio
+async def test_inverter_js_devicearray_sofar2200tl(
+    aresponses: ResponsesMockServer,
+) -> None:
+    """Test request from an SOFAR 2200TL Inverter - JS DeviceArray source."""
+    aresponses.add(
+        "example.com",
+        "/js/status.js",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/x-javascript"},
+            text=load_fixtures("status_devicearray_sofar220tl.js"),
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        client = OmnikInverter(host="example.com", session=session)
+        inverter: Inverter = await client.inverter()
+        assert inverter
+        assert inverter.serial_number == "1234567890"
+        assert inverter.firmware == "V450"
+        assert inverter.firmware_slave is None
+        assert inverter.model == "SOFAR2200TL"
+        assert inverter.solar_rated_power == 2000
+        assert inverter.solar_current_power == 400
+        assert inverter.solar_energy_today == 5.67
+        assert inverter.solar_energy_total == 12307.0
+
+
+@pytest.mark.asyncio
 async def test_device_js_devicearray(aresponses: ResponsesMockServer) -> None:
     """Test request from a Device - JS DeviceArray source."""
     aresponses.add(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -212,7 +212,7 @@ async def test_inverter_js_devicearray(aresponses: ResponsesMockServer) -> None:
         assert inverter.firmware == "V4.08Build215"
         assert inverter.firmware_slave == "V4.12Build246"
         assert inverter.model == "Omnik1500tl"
-        assert inverter.solar_rated_power == 1000
+        assert inverter.solar_rated_power is None
         assert inverter.solar_current_power == 850
         assert inverter.solar_energy_today == 2.32
         assert inverter.solar_energy_total == 5200.2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -212,7 +212,7 @@ async def test_inverter_js_devicearray(aresponses: ResponsesMockServer) -> None:
         assert inverter.firmware == "V4.08Build215"
         assert inverter.firmware_slave == "V4.12Build246"
         assert inverter.model == "Omnik1500tl"
-        assert inverter.solar_rated_power is None
+        assert inverter.solar_rated_power == 1000
         assert inverter.solar_current_power == 850
         assert inverter.solar_energy_today == 2.32
         assert inverter.solar_energy_total == 5200.2


### PR DESCRIPTION
I tried using this library for my SOFAR inverter and noticed it was failing due to a space while parsing integer for the rated power substring it tries to read from the `myDeviceArray` string.

I have fixed that issue, updated the test to test this edge case too, and also updated the documentation adding support for SOFAR 2200TL🥂 


**Error Log for reference:**
``` py
  File "/usr/local/lib/python3.10/site-packages/omnikinverter/omnikinverter.py", line 184, in inverter
    return Inverter.from_js(data)
  File "/usr/local/lib/python3.10/site-packages/omnikinverter/models.py", line 177, in from_js
    solar_rated_power=get_value(4),
  File "/usr/local/lib/python3.10/site-packages/omnikinverter/models.py", line 158, in get_value
    return int(matches[position])
ValueError: invalid literal for int() with base 10: '2 00'
```