### PR TITLE
Decouple network request from device/inverter parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ async def main():
         username="omnik",
         password="inverter",
     ) as client:
-        inverter = await client.inverter()
-        device = await client.device()
+        response = await client.perform_request()
+        inverter = response.inverter()
+        device = response.device()
         print(inverter)
         print(device)
 

--- a/examples/test_default.py
+++ b/examples/test_default.py
@@ -1,9 +1,11 @@
 # pylint: disable=W0621
 """Asynchronous Python client for the Omnik Inverter."""
 
+from __future__ import annotations
+
 import asyncio
 
-from omnikinverter import Device, Inverter, OmnikInverter
+from omnikinverter import Device, Inverter, OmnikInverter, TcpResponse, WebResponse
 
 
 async def main() -> None:
@@ -12,8 +14,9 @@ async def main() -> None:
         host="examples.com",
         source_type="javascript",
     ) as client:
-        inverter: Inverter = await client.inverter()
-        device: Device = await client.device()
+        response: WebResponse | TcpResponse = await client.perform_request()
+        inverter: Inverter = response.inverter()
+        device: Device = response.device()
         print(inverter)
         print()
         print("-- INVERTER --")

--- a/examples/test_tcp.py
+++ b/examples/test_tcp.py
@@ -16,7 +16,7 @@ async def main() -> None:
         source_type="tcp",
         serial_number=123456789,
     ) as client:
-        inverter: Inverter = await client.inverter()
+        inverter: Inverter = (await client.perform_request()).inverter()
         # TCP backend (currently?) doesn't provide WiFi module statistics,
         # so we're not querying .device() here.
         print(inverter)

--- a/src/omnikinverter/__init__.py
+++ b/src/omnikinverter/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     OmnikInverterWrongSourceError,
     OmnikInverterWrongValuesError,
 )
-from .models import Device, Inverter
+from .models import Device, Inverter, TcpResponse, WebResponse
 from .omnikinverter import OmnikInverter
 
 __all__ = [
@@ -17,4 +17,6 @@ __all__ = [
     "OmnikInverterError",
     "OmnikInverterWrongSourceError",
     "OmnikInverterWrongValuesError",
+    "TcpResponse",
+    "WebResponse",
 ]

--- a/src/omnikinverter/omnikinverter.py
+++ b/src/omnikinverter/omnikinverter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from dataclasses import dataclass
 from importlib import metadata
 from typing import Any, Self
@@ -18,7 +17,7 @@ from .exceptions import (
     OmnikInverterConnectionError,
     OmnikInverterError,
 )
-from .models import Device, Inverter
+from .models import TcpResponse, WebResponse
 
 VERSION = metadata.version(__package__)
 
@@ -171,7 +170,7 @@ class OmnikInverter:
 
         return tcp.parse_messages(self.serial_number, raw_msg)
 
-    async def inverter(self) -> Inverter:
+    async def perform_request(self) -> WebResponse | TcpResponse:
         """Get values from your Omnik Inverter.
 
         Returns
@@ -183,49 +182,21 @@ class OmnikInverter:
             OmnikInverterError: Unknown source type.
 
         """
-        if self.source_type == "json":
-            data = await self.request("status.json", params={"CMD": "inv_query"})
-            return Inverter.from_json(json.loads(data))
-        if self.source_type == "html":
-            data = await self.request("status.html")
-            return Inverter.from_html(data)
-        if self.source_type == "javascript":
-            data = await self.request("js/status.js")
-            return Inverter.from_js(data)
         if self.source_type == "tcp":
             fields = await self.tcp_request()
-            return Inverter.from_tcp(fields)
+            return TcpResponse(fields)
 
-        msg = f"Unknown source type `{self.source_type}`"
-        raise OmnikInverterError(msg)
-
-    async def device(self) -> Device:
-        """Get values from the device.
-
-        Returns
-        -------
-            A Device data object from the Omnik Inverter. None on the "tcp" source_type.
-
-        Raises
-        ------
-            OmnikInverterError: Unknown source type.
-
-        """
         if self.source_type == "json":
             data = await self.request("status.json", params={"CMD": "inv_query"})
-            return Device.from_json(json.loads(data))
-        if self.source_type == "html":
+        elif self.source_type == "html":
             data = await self.request("status.html")
-            return Device.from_html(data)
-        if self.source_type == "javascript":
+        elif self.source_type == "javascript":
             data = await self.request("js/status.js")
-            return Device.from_js(data)
-        if self.source_type == "tcp":
-            # None of the fields are available through a TCP data dump.
-            return Device()
+        else:
+            msg = f"Unknown source type `{self.source_type}`"
+            raise OmnikInverterError(msg)
 
-        msg = f"Unknown source type `{self.source_type}`"
-        raise OmnikInverterError(msg)
+        return WebResponse(response_string=data, source_type=self.source_type)
 
     async def close(self) -> None:
         """Close open client session."""

--- a/src/omnikinverter/tcp.py
+++ b/src/omnikinverter/tcp.py
@@ -213,7 +213,7 @@ def _unpack_message(message: bytearray) -> tuple[int, int, bytearray]:
 
     message_type = message.pop(0)
     LOGGER.debug(
-        "Message type %02x, length %s, checksum %02x",
+        "Message type %#02x, length %s, checksum %#02x",
         message_type,
         length,
         checksum,
@@ -330,7 +330,7 @@ def parse_messages(serial_number: int, data: bytes) -> dict[str, Any]:
             )
         else:
             msg = (
-                f"Unknown Omnik message type {message_type:02x} "
+                f"Unknown Omnik message type {message_type:#02x} "
                 f"with contents `{message}`"
             )
             raise OmnikInverterPacketInvalidError(msg)

--- a/src/omnikinverter/tcp.py
+++ b/src/omnikinverter/tcp.py
@@ -29,7 +29,7 @@ MESSAGE_HEADER_SIZE = 3 + 2 * 4 + 1
 
 
 class _AcOutput(BigEndianStructure):
-    _fields_: ClassVar[list[tuple[str, type[object]]]] = [
+    _fields_: ClassVar = [
         ("frequency", c_ushort),
         ("power", c_ushort),
     ]
@@ -57,7 +57,7 @@ class _AcOutput(BigEndianStructure):
 
 class _TcpData(BigEndianStructure):
     _pack_ = 1
-    _fields_: ClassVar[list[tuple[str, type[object]]]] = [
+    _fields_: ClassVar = [
         ("padding0", c_char * 3),
         ("serial_number", c_char * 16),
         ("temperature", c_ushort),
@@ -150,7 +150,7 @@ class _TcpData(BigEndianStructure):
 
 class _TcpFirmwareStrings(BigEndianStructure):
     _pack_ = 1
-    _fields_: ClassVar[list[tuple[str, type[object]]]] = [
+    _fields_: ClassVar = [
         ("firmware", c_char * 16),
         ("padding3", c_ubyte * 4),
         ("firmware_slave", c_char * 16),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,7 +31,7 @@ async def test_inverter_js_webdata(
 
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session)
-        inverter: Inverter = await client.inverter()
+        inverter: Inverter = (await client.perform_request()).inverter()
         assert inverter == snapshot
 
 
@@ -52,7 +52,7 @@ async def test_device_js_webdata(
 
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session)
-        device: Device = await client.device()
+        device: Device = (await client.perform_request()).device()
         assert device == snapshot
 
 
@@ -79,7 +79,7 @@ async def test_inverter_html(
             password="supercool",  # noqa: S106
             session=session,
         )
-        inverter: Inverter = await client.inverter()
+        inverter: Inverter = (await client.perform_request()).inverter()
         assert inverter == snapshot
 
 
@@ -106,7 +106,7 @@ async def test_device_html(
             password="supercool",  # noqa: S106
             session=session,
         )
-        device: Device = await client.device()
+        device: Device = (await client.perform_request()).device()
         assert device == snapshot
 
 
@@ -131,7 +131,7 @@ async def test_inverter_without_session(
         username="klaas",
         password="supercool",  # noqa: S106
     )
-    inverter: Inverter = await client.inverter()
+    inverter: Inverter = (await client.perform_request()).inverter()
     assert inverter == snapshot
 
 
@@ -156,7 +156,7 @@ async def test_device_without_session(
         username="klaas",
         password="supercool",  # noqa: S106
     )
-    device: Device = await client.device()
+    device: Device = (await client.perform_request()).device()
     assert device == snapshot
 
 
@@ -177,7 +177,7 @@ async def test_inverter_js_devicearray(
 
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session)
-        inverter: Inverter = await client.inverter()
+        inverter: Inverter = (await client.perform_request()).inverter()
         assert inverter == snapshot
 
 
@@ -199,7 +199,7 @@ async def test_inverter_js_devicearray_sofar2200tl(
 
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session)
-        inverter: Inverter = await client.inverter()
+        inverter: Inverter = (await client.perform_request()).inverter()
         assert inverter == snapshot
 
 
@@ -220,7 +220,7 @@ async def test_device_js_devicearray(
 
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session)
-        device: Device = await client.device()
+        device: Device = (await client.perform_request()).device()
         assert device == snapshot
 
 
@@ -241,7 +241,7 @@ async def test_inverter_json(
 
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", source_type="json", session=session)
-        inverter: Inverter = await client.inverter()
+        inverter: Inverter = (await client.perform_request()).inverter()
         assert inverter == snapshot
 
 
@@ -262,7 +262,7 @@ async def test_device_json(
 
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", source_type="json", session=session)
-        device: Device = await client.device()
+        device: Device = (await client.perform_request()).device()
         assert device == snapshot
 
 
@@ -282,14 +282,14 @@ async def test_wrong_values(aresponses: ResponsesMockServer) -> None:
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", source_type="json", session=session)
         with pytest.raises(OmnikInverterWrongValuesError):
-            assert await client.inverter()
+            assert (await client.perform_request()).inverter()
 
 
 async def test_inverter_unknown_source_type() -> None:
     """Test exception on wrong source type."""
     client = OmnikInverter(host="example.com", source_type="blah")
     with pytest.raises(OmnikInverterError) as excinfo:
-        assert await client.inverter()
+        assert (await client.perform_request()).inverter()
 
     assert str(excinfo.value) == "Unknown source type `blah`"
 
@@ -298,6 +298,6 @@ async def test_device_unknown_source_type() -> None:
     """Test exception on wrong source type."""
     client = OmnikInverter(host="example.com", source_type="blah")
     with pytest.raises(OmnikInverterError) as excinfo:
-        assert await client.device()
+        assert (await client.perform_request()).device()
 
     assert str(excinfo.value) == "Unknown source type `blah`"

--- a/tests/test_omnik.py
+++ b/tests/test_omnik.py
@@ -121,7 +121,7 @@ async def test_wrong_js_source(aresponses: ResponsesMockServer) -> None:
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session)
         with pytest.raises(OmnikInverterWrongSourceError):
-            assert await client.inverter()
+            assert (await client.perform_request()).inverter()
 
 
 async def test_wrong_html_source(aresponses: ResponsesMockServer) -> None:
@@ -146,7 +146,7 @@ async def test_wrong_html_source(aresponses: ResponsesMockServer) -> None:
             session=session,
         )
         with pytest.raises(OmnikInverterWrongSourceError):
-            assert await client.inverter()
+            assert (await client.perform_request()).inverter()
 
 
 async def test_html_no_auth(aresponses: ResponsesMockServer) -> None:
@@ -164,7 +164,7 @@ async def test_html_no_auth(aresponses: ResponsesMockServer) -> None:
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", source_type="html", session=session)
         with pytest.raises(OmnikInverterAuthError):
-            assert await client.inverter()
+            assert await client.perform_request()
 
 
 async def test_timeout(aresponses: ResponsesMockServer) -> None:
@@ -183,7 +183,7 @@ async def test_timeout(aresponses: ResponsesMockServer) -> None:
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session, request_timeout=0.1)
         with pytest.raises(OmnikInverterConnectionError):
-            assert await client.inverter()
+            assert await client.perform_request()
 
 
 async def test_content_type(aresponses: ResponsesMockServer) -> None:
@@ -201,7 +201,7 @@ async def test_content_type(aresponses: ResponsesMockServer) -> None:
     async with ClientSession() as session:
         client = OmnikInverter(host="example.com", session=session)
         with pytest.raises(OmnikInverterError):
-            assert await client.inverter()
+            assert await client.perform_request()
 
 
 async def test_client_error() -> None:

--- a/tests/test_tcp_models.py
+++ b/tests/test_tcp_models.py
@@ -178,7 +178,7 @@ async def test_inverter_tcp_known_message_type() -> None:
         )
 
     assert (
-        str(excinfo.value) == "Unknown Omnik message type 00 "
+        str(excinfo.value) == "Unknown Omnik message type 0x0 "
         "with contents `bytearray(b'')`"
     )
 

--- a/tests/test_tcp_models.py
+++ b/tests/test_tcp_models.py
@@ -273,7 +273,7 @@ async def test_inverter_tcp() -> None:
         tcp_port=port,
     )
 
-    inverter: Inverter = await client.inverter()
+    inverter: Inverter = (await client.perform_request()).inverter()
 
     assert inverter
     assert inverter.solar_rated_power is None
@@ -311,7 +311,7 @@ async def test_inverter_tcp_no_firmware() -> None:
         tcp_port=port,
     )
 
-    inverter: Inverter = await client.inverter()
+    inverter: Inverter = (await client.perform_request()).inverter()
 
     assert inverter
     assert inverter.solar_rated_power is None
@@ -349,7 +349,7 @@ async def test_inverter_tcp_offline() -> None:
         tcp_port=port,
     )
 
-    inverter: Inverter = await client.inverter()
+    inverter: Inverter = (await client.perform_request()).inverter()
 
     assert inverter
     assert inverter.solar_rated_power is None
@@ -401,7 +401,7 @@ async def test_connection_broken() -> None:
     )
 
     with pytest.raises(OmnikInverterConnectionError) as excinfo:
-        assert await client.inverter()
+        assert await client.perform_request()
 
     assert (
         str(excinfo.value)
@@ -431,7 +431,7 @@ async def test_communication_timeout() -> None:
     )
 
     with pytest.raises(OmnikInverterConnectionError) as excinfo:
-        assert await client.inverter()
+        assert await client.perform_request()
 
     assert (
         str(excinfo.value)
@@ -453,7 +453,7 @@ async def test_connection_failed() -> None:
     )
 
     with pytest.raises(OmnikInverterConnectionError) as excinfo:
-        assert await client.inverter()
+        assert await client.perform_request()
 
     assert (
         str(excinfo.value)
@@ -463,16 +463,21 @@ async def test_connection_failed() -> None:
 
 async def test_device_tcp_not_implemented() -> None:
     """Test request from a Device - TCP source."""
-    serial_number = 123456
+    serial_number = 987654321
+
+    (server_exit, port) = tcp_server(serial_number, "tcp_reply.data")
 
     client = OmnikInverter(
-        host="example.com",
+        host="localhost",
         source_type="tcp",
         serial_number=serial_number,
+        tcp_port=port,
     )
 
-    device: Device = await client.device()
+    device: Device = (await client.perform_request()).device()
     # No Device data can be extracted from TCP packets
     assert device.signal_quality is None
     assert device.firmware is None
     assert device.ip_address is None
+
+    await server_exit


### PR DESCRIPTION
Depends on #339

Currently both the `device()` and `inverter()` functions perform an identical web request, but parse the data into a different `dataclass`.  This is not only unnecessarily slow and wasteful but also seems to act up on certain inverters.

Remodel the code to return a wrapper object that encapsulates the reply from the inverter, and parse it into a specific `dataclass` only when the user asks for it.
