### PR TITLE
tcp: Fix typing of `_fields_` class variable

### DIFF
--- a/src/omnikinverter/tcp.py
+++ b/src/omnikinverter/tcp.py
@@ -29,7 +29,7 @@ MESSAGE_HEADER_SIZE = 3 + 2 * 4 + 1
 
 
 class _AcOutput(BigEndianStructure):
-    _fields_: ClassVar[list[tuple[str, type[object]]]] = [
+    _fields_: ClassVar = [
         ("frequency", c_ushort),
         ("power", c_ushort),
     ]
@@ -57,7 +57,7 @@ class _AcOutput(BigEndianStructure):
 
 class _TcpData(BigEndianStructure):
     _pack_ = 1
-    _fields_: ClassVar[list[tuple[str, type[object]]]] = [
+    _fields_: ClassVar = [
         ("padding0", c_char * 3),
         ("serial_number", c_char * 16),
         ("temperature", c_ushort),
@@ -150,7 +150,7 @@ class _TcpData(BigEndianStructure):
 
 class _TcpFirmwareStrings(BigEndianStructure):
     _pack_ = 1
-    _fields_: ClassVar[list[tuple[str, type[object]]]] = [
+    _fields_: ClassVar = [
         ("firmware", c_char * 16),
         ("padding3", c_ubyte * 4),
         ("firmware_slave", c_char * 16),


### PR DESCRIPTION
It seems our `mypy` tests have been failing on the typing of these class variables, which were specified as a full list of `str,object` tuples. Simplifying that to a `ClassVar` seems to make the test succeed again.

---

Separately I used `poetry update` locally to sync installed dependencies with the lockfile. While this doesn't seem to try and bump the locked dependencies to latest, it does rewrite the lockfile with a bunch of changes from a newer `poetry` (`2.1.2` versus `1.8.4`). Should this repo update that as well?
