### PR TITLE
Modernize package maintenance and security baseline

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,8 +47,6 @@
         "python.defaultInterpreterPath": ".venv/bin/python",
         "python.formatting.provider": "ruff",
         "python.linting.enabled": true,
-        "python.linting.mypyEnabled": true,
-        "python.linting.pylintEnabled": false,
         "python.testing.cwd": "${workspaceFolder}",
         "python.testing.pytestEnabled": true,
         "python.testing.pytestArgs": ["--cov-report=xml"],

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+We take the security of this project seriously. We appreciate your efforts to responsibly disclose your findings and will make every effort to acknowledge your contributions.
+
+## Reporting a Vulnerability
+
+**Do not submit security issues through GitHub Issues, Discussions, or Pull Requests.**
+
+If you believe you have discovered a security vulnerability, please submit it through GitHub’s private and encrypted reporting system:
+
+1. Open the **Security** tab of this repository
+2. Click **“Report a vulnerability”**
+3. Include a clear description, impact assessment (if known), and steps to reproduce
+
+You can also open a private vulnerability report directly:
+https://github.com/klaasnicolaas/python-omnikinverter/security/advisories/new
+
+This mechanism is the preferred and most secure way to report vulnerabilities, consistent with best practices across open-source projects.
+
+Security vulnerabilities include issues that could affect users of this Python package, such as unsafe handling of remote API data, credential exposure, dependency-related vulnerabilities, or behavior that could allow unintended access to local or remote resources.
+
+## What Happens Next
+
+After receiving your report, maintainers will:
+
+- Review the submitted information
+- Request additional details if necessary
+- Investigate and work toward a fix or mitigation
+- Communicate with you throughout the process
+
+Maintainers aim to acknowledge vulnerability reports within 7 days when possible. After confirmation, we will work on a fix or mitigation and coordinate disclosure with the reporter.
+
+For confirmed vulnerabilities, we generally aim to coordinate disclosure within 90 days. This is not a guaranteed deadline; the timeline may be shorter or longer depending on severity, exploitability, maintainer availability, and release coordination needs.
+
+## Coordinated Disclosure
+
+To protect the community, please:
+
+- Avoid publicly disclosing the vulnerability until a fix has been released
+- Limit testing or reproduction to what is necessary for your report
+- Follow coordinated disclosure norms commonly used in open source
+
+We appreciate your contribution to keeping this project secure!

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,19 @@
+---
+name: Dependency Review
+
+# yamllint disable-line rule:truthy
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: 👀 Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -10,18 +10,23 @@ on:
 env:
   DEFAULT_PYTHON: "3.12"
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: codespell
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "poetry"
@@ -39,12 +44,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "poetry"
@@ -64,12 +71,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "poetry"
@@ -106,40 +115,19 @@ jobs:
       - name: 🚀 Trim Trailing Whitespace
         run: poetry run prek run trailing-whitespace --all-files
 
-  pylint:
-    name: pylint
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
-      - name: 🏗 Set up Poetry
-        run: pipx install poetry
-      - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v6.3.0
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache: "poetry"
-      - name: 🏗 Install workflow dependencies
-        run: |
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-      - name: 🏗 Install Python dependencies
-        run: poetry install --no-interaction
-      - name: 🚀 Run pylint
-        run: poetry run prek run pylint --all-files
-
   yamllint:
     name: yamllint
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "poetry"
@@ -151,3 +139,28 @@ jobs:
         run: poetry install --no-interaction
       - name: 🚀 Run yamllint
         run: poetry run yamllint .
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: 🏗 Set up Poetry
+        run: pipx install poetry
+      - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache: "poetry"
+      - name: 🏗 Install workflow dependencies
+        run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+      - name: 🏗 Install Python dependencies
+        run: poetry install --no-interaction
+      - name: 🚀 Run zizmor
+        run: poetry run zizmor .github/workflows/

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -7,6 +7,9 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   inactivity-lock:
     name: Lock issues and PRs
@@ -16,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: 🔒 Lock closed issues and PRs
-        uses: klaasnicolaas/action-inactivity-lock@v2.0.1
+        uses: klaasnicolaas/action-inactivity-lock@0ee41c932b9b4e52b8333c6ede0c69403681ebe2 # v2.0.1
         with:
           days-inactive-issues: 30
           lock-reason-issues: ""

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,13 +3,16 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - labeled
       - unlabeled
       - synchronize
   workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   validate:
@@ -20,7 +23,7 @@ jobs:
       pull-requests: read
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: klaasnicolaas/action-pr-labels@v3.1.1
+        uses: klaasnicolaas/action-pr-labels@d9167db247c8e0a7909b45503ec356b0fe77e913 # v3.1.1
         with:
           valid-labels: >-
             breaking-change, bugfix, documentation, enhancement, sync,

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
     name: ✏️ Draft release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,24 +11,29 @@ on:
 env:
   DEFAULT_PYTHON: "3.12"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Releasing to PyPi
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
-          cache: "poetry"
       - name: 🏗 Install workflow dependencies
         run: |
           poetry config virtualenvs.create true
@@ -36,32 +41,31 @@ jobs:
       - name: 🏗 Install dependencies
         run: poetry install --no-interaction
       - name: 🏗 Set package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          version="${{ github.event.release.tag_name }}"
+          version="${RELEASE_TAG}"
           version="${version,,}"
           version="${version#v}"
           poetry version --no-interaction "${version}"
       - name: 🏗 Build package
         run: poetry build --no-interaction
       - name: 🚀 Publish package to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
-  tweet:
-    name: 🐦 Tweet the release
+  bluesky:
+    name: 🦋 Post to Bluesky
     runs-on: ubuntu-latest
+    environment: release
     needs: release
+    permissions: {}
     steps:
-      - uses: Eomm/why-don-t-you-tweet@v2.0.0
+      - name: 🦋 Post to Bluesky
+        uses: myConsciousness/bluesky-post@96827d0a9604cb228b11b3095f6961196efba4a0 # v5.0.0
         with:
-          # GitHub event payload
-          # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
-          tweet-message: |
-            ⬆️ ${{ github.event.release.tag_name }} of ${{ github.event.repository.name }} just released 🎉 #update @klaasnicolaas #python #package #omnik #inverter #release #bot #assistant
+          text: |
+            ⬆️ ${{ github.event.release.tag_name }} of ${{ github.event.repository.name }} just released 🎉 #update @klaasnicolaas.nl #python #package #omnik #inverter #release
 
             Check out the release notes here: ${{ github.event.release.html_url }}
-        env:
-          # Get your tokens from https://developer.twitter.com/apps
-          TWITTER_CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-          TWITTER_CONSUMER_API_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
-          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
+          password: ${{ secrets.BLUESKY_PASSWORD }}

--- a/.github/workflows/scoreboard.yaml
+++ b/.github/workflows/scoreboard.yaml
@@ -1,0 +1,86 @@
+---
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+"on":
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '20 0 * * 3'
+  push:
+    branches: ["main"]
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
+    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public*
+          #   repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in:
+          # https://github.com/ossf/scorecard-action?tab=readme-ov-file
+          # #authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+          # (Optional) Uncomment file_mode if you have a .gitattributes with
+          # files marked export-ignore
+          # file_mode: git
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code
+      # Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,9 @@ on:
     - cron: "0 1 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     name: 🧹 Clean up stale issues and PRs
@@ -16,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: 🚀 Run stale
-        uses: actions/stale@v10.4.0
+        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,9 @@ on:
 env:
   DEFAULT_PYTHON: "3.12"
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     name: Python ${{ matrix.python }}
@@ -19,12 +22,14 @@ jobs:
         python: ["3.12", "3.13", "3.14"]
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ matrix.python }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
           cache: "poetry"
@@ -37,7 +42,7 @@ jobs:
       - name: 🚀 Run pytest
         run: poetry run pytest --cov src tests
       - name: ⬆️ Upload coverage artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-${{ matrix.python }}
           include-hidden-files: true
@@ -45,19 +50,21 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    environment: testing
     needs: pytest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: ⬇️ Download coverage data
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "poetry"
@@ -72,6 +79,6 @@ jobs:
           poetry run coverage combine coverage*/.coverage*
           poetry run coverage xml -i
       - name: 🚀 Upload coverage report
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/typing.yaml
+++ b/.github/workflows/typing.yaml
@@ -10,18 +10,23 @@ on:
 env:
   DEFAULT_PYTHON: "3.12"
 
+permissions:
+  contents: read
+
 jobs:
   ty:
     name: ty
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🏗 Set up Poetry
         run: pipx install poetry
       - name: 🏗 Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "poetry"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,14 @@ repos:
         types: [python]
         entry: poetry run ruff check --fix
         require_serial: true
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: ruff-format
         name: 🐶 Ruff Formatter
         language: system
         types: [python]
         entry: poetry run ruff format
         require_serial: true
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: check-ast
         name: 🐍 Check Python AST
         language: system
@@ -35,7 +35,7 @@ repos:
         language: system
         types: [text, executable]
         entry: poetry run check-executables-have-shebangs
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: check-json
         name: ｛ Check JSON files
         language: system
@@ -82,12 +82,13 @@ repos:
         language: system
         types: [text]
         entry: poetry run end-of-file-fixer
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: ty
         name: 🆎 Static type checking using ty
         language: system
         types: [python]
-        entry: poetry run ty check
+        entry: poetry run ty check examples src tests
+        pass_filenames: false
       - id: no-commit-to-branch
         name: 🛑 Don't commit to main branch
         language: system
@@ -102,11 +103,6 @@ repos:
         entry: poetry check
         pass_filenames: false
         always_run: true
-      - id: pylint
-        name: 🌟 Starring code with pylint
-        language: system
-        types: [python]
-        entry: poetry run pylint
       - id: pytest
         name: 🧪 Running tests and test coverage with pytest
         language: system
@@ -118,9 +114,14 @@ repos:
         language: system
         types: [text]
         entry: poetry run trailing-whitespace-fixer
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: yamllint
         name: 🎗 Check YAML files with yamllint
         language: system
         types: [yaml]
         entry: poetry run yamllint
+      - id: zizmor
+        name: 🌈 Check GitHub Actions workflows with zizmor
+        language: system
+        entry: poetry run zizmor
+        files: ^\.github/workflows/.*\.ya?ml$

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021-2025 Klaas Schoute
+Copyright (c) 2021-2026 Klaas Schoute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![Build Status][build-shield]][build-url]
 [![Typing Status][typing-shield]][typing-url]
 [![Code Coverage][codecov-shield]][codecov-url]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
 
 Asynchronous Python client for the Omnik Inverter.
 
@@ -184,7 +185,7 @@ poetry run pytest --snapshot-update
 
 MIT License
 
-Copyright (c) 2021-2025 Klaas Schoute
+Copyright (c) 2021-2026 Klaas Schoute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -220,7 +221,7 @@ SOFTWARE.
 [downloads-url]: https://pypistats.org/packages/omnikinverter
 [license-shield]: https://img.shields.io/github/license/klaasnicolaas/python-omnikinverter.svg
 [last-commit-shield]: https://img.shields.io/github/last-commit/klaasnicolaas/python-omnikinverter.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
 [pypi]: https://pypi.org/project/omnikinverter/
 [python-versions-shield]: https://img.shields.io/pypi/pyversions/omnikinverter
@@ -230,3 +231,5 @@ SOFTWARE.
 [poetry-install]: https://python-poetry.org/docs/#installation
 [poetry]: https://python-poetry.org
 [prek]: https://prek.j178.dev/
+[scorecard-shield]: https://api.scorecard.dev/projects/github.com/klaasnicolaas/python-omnikinverter/badge
+[scorecard-url]: https://scorecard.dev/viewer/?uri=github.com/klaasnicolaas/python-omnikinverter

--- a/examples/test_default.py
+++ b/examples/test_default.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0621
 """Asynchronous Python client for the Omnik Inverter."""
 
 import asyncio

--- a/examples/test_tcp.py
+++ b/examples/test_tcp.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0621
 """Asynchronous TCP Python client for the Omnik Inverter."""
 
 import asyncio

--- a/poetry.lock
+++ b/poetry.lock
@@ -187,18 +187,6 @@ aiohttp = {version = ">=3.7.0,<3.8.dev0 || >=3.9.dev0", markers = "python_versio
 pytest-asyncio = {version = ">=0.17.0", markers = "python_version >= \"3.7\""}
 
 [[package]]
-name = "astroid"
-version = "4.0.4"
-description = "An abstract syntax tree for Python with inference support."
-optional = false
-python-versions = ">=3.10.0"
-groups = ["dev"]
-files = [
-    {file = "astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753"},
-    {file = "astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0"},
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 description = "Classes Without Boilerplate"
@@ -389,22 +377,6 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
-name = "dill"
-version = "0.4.1"
-description = "serialize all of Python"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d"},
-    {file = "dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
-profile = ["gprof2dot (>=2022.7.29)"]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -569,33 +541,6 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
-]
-
-[[package]]
-name = "isort"
-version = "8.0.1"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.10.0"
-groups = ["dev"]
-files = [
-    {file = "isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75"},
-    {file = "isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d"},
-]
-
-[package.extras]
-colors = ["colorama"]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -782,18 +727,6 @@ files = [
 hyperscan = ["hyperscan (>=0.7)"]
 optional = ["typing-extensions (>=4)"]
 re2 = ["google-re2 (>=1.1)"]
-
-[[package]]
-name = "platformdirs"
-version = "4.11.3"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7"},
-    {file = "platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab"},
-]
 
 [[package]]
 name = "pluggy"
@@ -990,31 +923,6 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
-
-[[package]]
-name = "pylint"
-version = "4.0.8"
-description = "python code static checker"
-optional = false
-python-versions = ">=3.10.0"
-groups = ["dev"]
-files = [
-    {file = "pylint-4.0.8-py3-none-any.whl", hash = "sha256:3341c08c0aabaa4adc71516de0969f3ba5c692b56c75af4dcb4d242823fbe363"},
-    {file = "pylint-4.0.8.tar.gz", hash = "sha256:1c1b2128bde5ff5e966801413080b6384d42a5782718d528c906dbb6beab94ed"},
-]
-
-[package.dependencies]
-astroid = ">=4.0.2,<=4.1.dev0"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = {version = ">=0.3.7", markers = "python_version >= \"3.12\""}
-isort = ">=5,<5.13 || >5.13,<10"
-mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2"
-tomlkit = ">=0.10.1"
-
-[package.extras]
-spelling = ["pyenchant (>=3.2,<4.0)"]
-testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
@@ -1223,18 +1131,6 @@ files = [
 pytest = ">=8.0.0"
 
 [[package]]
-name = "tomlkit"
-version = "0.15.1"
-description = "Style preserving TOML library"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304"},
-    {file = "tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97"},
-]
-
-[[package]]
 name = "ty"
 version = "0.0.78"
 description = "An extremely fast Python type checker, written in Rust."
@@ -1413,7 +1309,28 @@ idna = ">=2.0"
 multidict = ">=4.0"
 propcache = ">=0.2.1"
 
+[[package]]
+name = "zizmor"
+version = "1.30.0"
+description = "Static analysis for GitHub Actions"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "zizmor-1.30.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51c96204572b9f96b940806a371a9c57c8cff30cf93d3bd73c2febe483f942df"},
+    {file = "zizmor-1.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4193537785dd07177227e4695871ffae1d7fe3f6043c217498445e71b477bc1"},
+    {file = "zizmor-1.30.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:7569a58319fb270c14a64663a6565929035f26f6f6d13059314f796e988129eb"},
+    {file = "zizmor-1.30.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0e69a86290dff4c41b51c381a27029b5dc2b748c0510a9a333b18f862ea1bc68"},
+    {file = "zizmor-1.30.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9c08a7c34b33ed6f9a3a3d28fcf8c64e3e078c53c51bc9ce05c32ec3ba7feae9"},
+    {file = "zizmor-1.30.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:baa02978518248bf9f011e6ceca7b7c5efb5b893810cd4954e01785e1b68f959"},
+    {file = "zizmor-1.30.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0148b61f6315ad363ae748f838e8ed81e1cfb3ade6bbe480e7516e4fba630b82"},
+    {file = "zizmor-1.30.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f15ed62ff34ad7875427384b03a2f72995d9ab8ddcb50dc141b25763de3aaa2"},
+    {file = "zizmor-1.30.0-py3-none-win32.whl", hash = "sha256:39f15155db3e4af9bb5cf125a236c67fd84ddd3174f60b4111b27c691b337e00"},
+    {file = "zizmor-1.30.0-py3-none-win_amd64.whl", hash = "sha256:ca321b5b1cb85d08ac0c3c86275bfd5a6b5564c176437e3b41e10bd1e4463296"},
+    {file = "zizmor-1.30.0.tar.gz", hash = "sha256:9a17ac3bb043afbbd9d3c8b6f309fa5b319c6a32e3259fbaf050f6fcd3d0a9cd"},
+]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "3cced5d73abcae07355e88f5105cbe671b0d273feefb32d1c842a8365c7d415b"
+content-hash = "d66358105ab597281fde27bdbec5de69932a5e3641d5af0e433165bb4ab8a5a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,10 @@
 name = "omnikinverter"
 version = "0.0.0"
 description = "Asynchronous Python client for the Omnik Inverter"
-authors = [{ name="Klaas Schoute", email="<hello@student-techlife.com>"}]
-maintainers = [{name="Klaas Schoute", email="<hello@student-techlife.com>"}]
+authors = [{ name="Klaas Schoute", email="hello@student-techlife.com"}]
+maintainers = [{name="Klaas Schoute", email="hello@student-techlife.com"}]
 license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 readme = "README.md"
 keywords = ["omnik", "inverter", "power", "energy", "async", "client"]
@@ -12,7 +13,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: AsyncIO",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -20,15 +20,19 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dynamic = ["dependencies"]
+
+dependencies = [
+  "aiohttp>=3.0.0",
+  "yarl>=1.6.0",
+]
+
+[tool.poetry]
 packages = [
   { include = "omnikinverter", from = "src" },
 ]
 
 [tool.poetry.dependencies]
-aiohttp = ">=3.0.0"
 python = "^3.12"
-yarl = ">=1.6.0"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/klaasnicolaas/python-omnikinverter/issues"
@@ -44,7 +48,6 @@ covdefaults = "2.3.0"
 coverage = {version = "7.16.0", extras = ["toml"]}
 pre-commit-hooks = "6.0.0"
 prek = "0.5.2"
-pylint = "4.0.8"
 pytest = "9.1.1"
 pytest-asyncio = "1.4.0"
 pytest-cov = "7.1.0"
@@ -52,6 +55,7 @@ ruff = "0.16.6"
 syrupy = "6.0.0"
 ty = "0.0.78"
 yamllint = "1.38.0"
+zizmor = "1.30.0"
 
 [tool.coverage.run]
 plugins = ["covdefaults"]
@@ -61,28 +65,8 @@ source = ["omnikinverter"]
 fail_under = 90
 show_missing = true
 
-[tool.pylint.MASTER]
-ignore = ["tests"]
-
-[tool.pylint.BASIC]
-good-names = ["_", "ex", "fp", "i", "id", "j", "k", "on", "Run", "T"]
-
-[tool.pylint."MESSAGES CONTROL"]
-disable= [
-  "too-few-public-methods",
-  "duplicate-code",
-  "format",
-  "unsubscriptable-object",
-]
-
-[tool.pylint.SIMILARITIES]
-ignore-imports = true
-
-[tool.pylint.FORMAT]
-max-line-length = 88
-
-[tool.pylint.DESIGN]
-max-attributes = 20
+[tool.ty.environment]
+python-version = "3.12"
 
 [tool.pytest.ini_options]
 addopts = "--cov"
@@ -116,4 +100,4 @@ max-complexity = 25
 
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.2.0"]

--- a/src/omnikinverter/omnikinverter.py
+++ b/src/omnikinverter/omnikinverter.py
@@ -20,7 +20,7 @@ from .exceptions import (
 )
 from .models import Device, Inverter
 
-VERSION: str = metadata.version(__package__)  # ty:ignore[invalid-argument-type]
+VERSION: str = metadata.version("omnikinverter")
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared client fixtures for Omnik tests."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from aiohttp import ClientSession
+
+from omnikinverter import OmnikInverter
+
+
+@pytest.fixture
+async def omnik_client() -> AsyncGenerator[OmnikInverter, None]:
+    """Provide a JavaScript client with an externally managed HTTP session."""
+    async with ClientSession() as session:
+        yield OmnikInverter(host="example.com", session=session)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,9 @@ from . import load_fixtures
 
 
 async def test_inverter_js_webdata(
-    aresponses: ResponsesMockServer, snapshot: SnapshotAssertion
+    aresponses: ResponsesMockServer,
+    snapshot: SnapshotAssertion,
+    omnik_client: OmnikInverter,
 ) -> None:
     """Test request from an Inverter - JS Webdata source."""
     aresponses.add(
@@ -29,14 +31,14 @@ async def test_inverter_js_webdata(
         ),
     )
 
-    async with ClientSession() as session:
-        client = OmnikInverter(host="example.com", session=session)
-        inverter: Inverter = await client.inverter()
-        assert inverter == snapshot
+    inverter: Inverter = await omnik_client.inverter()
+    assert inverter == snapshot
 
 
 async def test_device_js_webdata(
-    aresponses: ResponsesMockServer, snapshot: SnapshotAssertion
+    aresponses: ResponsesMockServer,
+    snapshot: SnapshotAssertion,
+    omnik_client: OmnikInverter,
 ) -> None:
     """Test request from a Device - JS Webdata source."""
     aresponses.add(
@@ -50,10 +52,8 @@ async def test_device_js_webdata(
         ),
     )
 
-    async with ClientSession() as session:
-        client = OmnikInverter(host="example.com", session=session)
-        device: Device = await client.device()
-        assert device == snapshot
+    device: Device = await omnik_client.device()
+    assert device == snapshot
 
 
 async def test_inverter_html(


### PR DESCRIPTION
Complete the package maintenance baseline: use ty consistently, remove Pylint, modernize package metadata and add the missing security workflows and OpenSSF Scorecard badge. Check the README maintenance year and LICENSE copyright for 2026.

The release workflow uses scoped permissions, pinned actions and safe tag handling. Bluesky posting follows a successful release without an optional credentials guard. Existing shared Release Drafter/Renovate configuration and central label synchronization remain in use.

Runtime dependency bounds and existing locked versions are preserved. Private vulnerability reporting is enabled and ty is a required status check.

Validation: 42 tests pass with 100% coverage; ty, all pre-commit hooks and strict Poetry checks pass. Both distributions build, and wheel license/dependency metadata is verified.

Shared HTTP client fixtures now serve the JavaScript model tests; existing JS, JSON, HTML and TCP behavior and tests are retained. Hardware and downstream integration were not exercised live.